### PR TITLE
Move all API routes from /api to /app/api (App Router format)

### DIFF
--- a/app/api/admin/audit/route.ts
+++ b/app/api/admin/audit/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { auth } from "../../src/auth";
-import { getAuditLog, countAuditLog } from "../../src/audit-log";
+import { auth } from "../../../../src/auth";
+import { getAuditLog, countAuditLog } from "../../../../src/audit-log";
 
 export const runtime = "nodejs";
 

--- a/app/api/admin/export/route.ts
+++ b/app/api/admin/export/route.ts
@@ -1,9 +1,9 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { auth } from "../../src/auth";
-import { getScanReport } from "../../src/scan-store";
-import { renderReportHtml } from "../../src/reporter";
-import { logAudit } from "../../src/audit-log";
+import { auth } from "../../../../src/auth";
+import { getScanReport } from "../../../../src/scan-store";
+import { renderReportHtml } from "../../../../src/reporter";
+import { logAudit } from "../../../../src/audit-log";
 
 export const runtime = "nodejs";
 

--- a/app/api/admin/false-positives/route.ts
+++ b/app/api/admin/false-positives/route.ts
@@ -1,13 +1,13 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { auth } from "../../src/auth";
+import { auth } from "../../../../src/auth";
 import {
   listFalsePositives,
   markFalsePositive,
   unmarkFalsePositive,
   type FalsePositive,
-} from "../../src/scan-store";
-import { logAudit } from "../../src/audit-log";
+} from "../../../../src/scan-store";
+import { logAudit } from "../../../../src/audit-log";
 
 export const runtime = "nodejs";
 

--- a/app/api/admin/scans/route.ts
+++ b/app/api/admin/scans/route.ts
@@ -1,18 +1,18 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { auth } from "../../src/auth";
-import { getScanReports, getScanReport, countScanReports } from "../../src/scan-store";
-import { logAudit } from "../../src/audit-log";
-import { listPublicRepos, getRepoTree, getFileContent } from "../../src/github";
-import { scanForSecrets } from "../../src/secrets";
-import { scanForPii } from "../../src/pii";
-import { scanForDependencyVulns } from "../../src/dependencies";
-import { analyzeWithDeepSeek } from "../../src/deepseek";
-import { buildReport } from "../../src/reporter";
-import { sendReportEmail } from "../../src/email";
-import { saveScanReport } from "../../src/scan-store";
-import { getSubscriber, generateUnsubscribeToken, updateLastScan } from "../../src/subscribers";
-import type { Finding } from "../../src/types";
+import { auth } from "../../../../src/auth";
+import { getScanReports, getScanReport, countScanReports } from "../../../../src/scan-store";
+import { logAudit } from "../../../../src/audit-log";
+import { listPublicRepos, getRepoTree, getFileContent } from "../../../../src/github";
+import { scanForSecrets } from "../../../../src/secrets";
+import { scanForPii } from "../../../../src/pii";
+import { scanForDependencyVulns } from "../../../../src/dependencies";
+import { analyzeWithDeepSeek } from "../../../../src/deepseek";
+import { buildReport } from "../../../../src/reporter";
+import { sendReportEmail } from "../../../../src/email";
+import { saveScanReport } from "../../../../src/scan-store";
+import { getSubscriber, generateUnsubscribeToken, updateLastScan } from "../../../../src/subscribers";
+import type { Finding } from "../../../../src/types";
 
 export const runtime = "nodejs";
 

--- a/app/api/admin/subscribers/route.ts
+++ b/app/api/admin/subscribers/route.ts
@@ -1,8 +1,8 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { auth } from "../../src/auth";
-import { listSubscribers, addSubscriber, removeSubscriber } from "../../src/subscribers";
-import { logAudit } from "../../src/audit-log";
+import { auth } from "../../../../src/auth";
+import { listSubscribers, addSubscriber, removeSubscriber } from "../../../../src/subscribers";
+import { logAudit } from "../../../../src/audit-log";
 
 export const runtime = "nodejs";
 

--- a/app/api/scan-once/route.ts
+++ b/app/api/scan-once/route.ts
@@ -1,17 +1,17 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { ScanOnceInput } from "../src/types";
-import { listPublicRepos, getRepoTree, getFileContent } from "../src/github";
-import { scanForSecrets } from "../src/secrets";
-import { scanForPii } from "../src/pii";
-import { scanForDependencyVulns } from "../src/dependencies";
-import { buildReport } from "../src/reporter";
-import { sendReportEmail } from "../src/email";
+import { ScanOnceInput } from "../../../src/types";
+import { listPublicRepos, getRepoTree, getFileContent } from "../../../src/github";
+import { scanForSecrets } from "../../../src/secrets";
+import { scanForPii } from "../../../src/pii";
+import { scanForDependencyVulns } from "../../../src/dependencies";
+import { buildReport } from "../../../src/reporter";
+import { sendReportEmail } from "../../../src/email";
 import {
   addSubscriber,
   getSubscriber,
   generateUnsubscribeToken,
-} from "../src/subscribers";
+} from "../../../src/subscribers";
 import { Redis } from "@upstash/redis";
 
 // ---------------------------------------------------------------------------
@@ -61,7 +61,7 @@ export async function POST(request: NextRequest) {
   try {
     // Scan all public repos (no DeepSeek)
     const repos = await listPublicRepos(githubUsername);
-    const allFindings: import("../src/types").Finding[] = [];
+    const allFindings: import("../../../src/types").Finding[] = [];
 
     for (const repo of repos) {
       try {

--- a/app/api/scan/route.ts
+++ b/app/api/scan/route.ts
@@ -1,18 +1,18 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import type { Finding } from "../src/types";
-import { listPublicRepos, getRepoTree, getFileContent } from "../src/github";
-import { scanForSecrets } from "../src/secrets";
-import { scanForPii } from "../src/pii";
-import { scanForDependencyVulns } from "../src/dependencies";
-import { analyzeWithDeepSeek } from "../src/deepseek";
-import { buildReport } from "../src/reporter";
-import { sendReportEmail } from "../src/email";
+import type { Finding } from "../../../src/types";
+import { listPublicRepos, getRepoTree, getFileContent } from "../../../src/github";
+import { scanForSecrets } from "../../../src/secrets";
+import { scanForPii } from "../../../src/pii";
+import { scanForDependencyVulns } from "../../../src/dependencies";
+import { analyzeWithDeepSeek } from "../../../src/deepseek";
+import { buildReport } from "../../../src/reporter";
+import { sendReportEmail } from "../../../src/email";
 import {
   listSubscribers,
   updateLastScan,
   generateUnsubscribeToken,
-} from "../src/subscribers";
+} from "../../../src/subscribers";
 
 // ---------------------------------------------------------------------------
 // Daily cron endpoint — POST /api/scan

--- a/app/api/subscribers/route.ts
+++ b/app/api/subscribers/route.ts
@@ -5,7 +5,7 @@ import {
   addSubscriber,
   removeSubscriber,
   verifyUnsubscribeToken,
-} from "../src/subscribers";
+} from "../../../src/subscribers";
 
 // ---------------------------------------------------------------------------
 // Subscriber CRUD — GET/POST/DELETE /api/subscribers

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     ],
     "module": "esnext",
     "moduleResolution": "bundler",
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
@@ -33,7 +33,8 @@
     "**/*.ts",
     "**/*.tsx",
     "next-env.d.ts",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/vercel.json
+++ b/vercel.json
@@ -4,13 +4,5 @@
       "path": "/api/scan",
       "schedule": "0 6 * * *"
     }
-  ],
-  "functions": {
-    "api/scan.ts": {
-      "maxDuration": 300
-    },
-    "api/scan-once.ts": {
-      "maxDuration": 120
-    }
-  }
+  ]
 }


### PR DESCRIPTION
Vercel with Next.js 16 requires API routes inside app/api/ as route.ts files. Moved all endpoints and fixed import paths. Removed old /api folder.

Build confirms all routes are registered:
- /api/scan, /api/scan-once, /api/subscribers
- /api/admin/subscribers, /api/admin/scans, /api/admin/audit
- /api/admin/false-positives, /api/admin/export
- /api/auth/[...nextauth]
- /admin/* pages

https://claude.ai/code/session_01Q73ZRw6qnkkMmo8THhtfBN