### PR TITLE
Fix ERR_TOO_MANY_REDIRECTS on admin page by moving login outside admi…

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -10,7 +10,7 @@ export default async function AdminLayout({
   const session = await auth();
 
   if (!session?.user) {
-    redirect("/admin/login");
+    redirect("/login");
   }
 
   const username = (session.user as Record<string, unknown>).githubUsername as string ?? session.user.email ?? "";

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -10,6 +10,7 @@ export default function LoginPage() {
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
+        background: "#1e1e1e",
       }}
     >
       <div

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -48,8 +48,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   },
 
   pages: {
-    signIn: "/admin/login",
-    error: "/admin/login",
+    signIn: "/login",
+    error: "/login",
   },
 
   session: {


### PR DESCRIPTION
…n layout

The login page was inside app/admin/login/ which is a child of the admin layout. The admin layout checks for auth and redirects unauthenticated users to the login page, creating an infinite redirect loop. Moved login to app/login/ (outside admin layout) and updated all redirect paths.

https://claude.ai/code/session_01Q73ZRw6qnkkMmo8THhtfBN